### PR TITLE
Fix RemoveDistributionFolder deleting parent directory instead of dis…

### DIFF
--- a/LinuxManager/Package.appxmanifest
+++ b/LinuxManager/Package.appxmanifest
@@ -14,7 +14,7 @@
   <Identity
     Name="14543NathanQuellec.WSLStudio"
     Publisher="CN=BAAB9B9E-CD72-40AB-BE14-24DCE13BA387"
-    Version="0.10.0.0" />
+    Version="0.11.0.0" />
 
   <Properties>
     <DisplayName>Linux Manager</DisplayName>

--- a/LinuxManager/Services/DistributionService.cs
+++ b/LinuxManager/Services/DistributionService.cs
@@ -143,7 +143,12 @@ public class DistributionService : IDistributionService
 
     private static void RemoveDistributionFolder(Distribution distribution)
     {
-        var distroPath = Directory.GetParent(distribution.Path).FullName;
+        var distroPath = distribution.Path;
+        if (!distroPath.StartsWith(App.DistroDirPath, StringComparison.OrdinalIgnoreCase))
+        {
+            Log.Warning($"Skipping folder deletion for {distribution.Name}: path is outside managed directory.");
+            return;
+        }
         if (Directory.Exists(distroPath))
         {
             Directory.Delete(distroPath, true);


### PR DESCRIPTION
distribution.Path (WSL registry BasePath) is already a directory, so calling Directory.GetParent() navigated one level too high and deleted the parent folder, wiping unrelated VMs and disk images stored alongside the WSL subfolder.

Now deletes distribution.Path directly, and only proceeds when the path is inside App.DistroDirPath to prevent accidental deletion of user-managed locations.

Bump version 0.10.0 → 0.11.0.