### PR TITLE
Add LinuxManager.Tests unit test project (94 tests) + fix toast COM activator name

### DIFF
--- a/LinuxManager.Tests/Builders/DistributionBuilderTests.cs
+++ b/LinuxManager.Tests/Builders/DistributionBuilderTests.cs
@@ -1,0 +1,94 @@
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using LinuxManager.Models;
+
+namespace LinuxManager.Tests.Builders;
+
+public class DistributionBuilderTests
+{
+    [Fact]
+    public void Build_WithNoConfiguration_ReturnsDistributionWithDefaults()
+    {
+        // Arrange
+        var builder = new DistributionBuilder();
+
+        // Act
+        var distro = builder.Build();
+
+        // Assert
+        distro.Should().NotBeNull();
+        distro.Users.Should().NotBeNull().And.BeEmpty();
+        distro.Snapshots.Should().NotBeNull().And.BeEmpty();
+        distro.RunningProcesses.Should().NotBeNull().And.BeEmpty();
+    }
+
+    [Fact]
+    public void Build_WithAllPropertiesConfigured_ReturnsFullyPopulatedDistribution()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var diskUsage = new DiskUsageInfo { Size = "100G" };
+        var users = new List<string> { "root", "nathan" };
+        var snapshots = new ObservableCollection<Snapshot> { new() { Name = "snap1" } };
+        var processes = new List<Process>();
+
+        // Act
+        var distro = new DistributionBuilder()
+            .WithId(id)
+            .WithName("Ubuntu")
+            .WithPath(@"C:\distros\ubuntu")
+            .WithWslVersion(2)
+            .WithOsName("Ubuntu")
+            .WithOsVersion("22.04")
+            .WithDiskUsageInfo(diskUsage)
+            .WithUsers(users)
+            .WithSnapshots(snapshots)
+            .WithRunningProcesses(processes)
+            .Build();
+
+        // Assert
+        distro.Id.Should().Be(id);
+        distro.Name.Should().Be("Ubuntu");
+        distro.Path.Should().Be(@"C:\distros\ubuntu");
+        distro.WslVersion.Should().Be(2);
+        distro.OsName.Should().Be("Ubuntu");
+        distro.OsVersion.Should().Be("22.04");
+        distro.DiskUsageInfo.Should().BeSameAs(diskUsage);
+        distro.Users.Should().BeSameAs(users);
+        distro.Snapshots.Should().BeSameAs(snapshots);
+        distro.RunningProcesses.Should().BeSameAs(processes);
+    }
+
+    [Fact]
+    public void WithMethods_WhenCalled_ReturnSameBuilderForChaining()
+    {
+        // Arrange
+        var builder = new DistributionBuilder();
+
+        // Act / Assert
+        builder.WithId(Guid.NewGuid()).Should().BeSameAs(builder);
+        builder.WithName("a").Should().BeSameAs(builder);
+        builder.WithPath("p").Should().BeSameAs(builder);
+        builder.WithWslVersion(1).Should().BeSameAs(builder);
+        builder.WithOsName("os").Should().BeSameAs(builder);
+        builder.WithOsVersion("1.0").Should().BeSameAs(builder);
+        builder.WithDiskUsageInfo(new DiskUsageInfo()).Should().BeSameAs(builder);
+        builder.WithUsers(new List<string>()).Should().BeSameAs(builder);
+        builder.WithSnapshots(new ObservableCollection<Snapshot>()).Should().BeSameAs(builder);
+        builder.WithRunningProcesses(new List<Process>()).Should().BeSameAs(builder);
+    }
+
+    [Fact]
+    public void Build_WhenCalledTwice_ReturnsSameUnderlyingInstance()
+    {
+        // Arrange
+        var builder = new DistributionBuilder().WithName("Ubuntu");
+
+        // Act
+        var first = builder.Build();
+        var second = builder.Build();
+
+        // Assert
+        first.Should().BeSameAs(second);
+    }
+}

--- a/LinuxManager.Tests/Builders/ProcessBuilderTests.cs
+++ b/LinuxManager.Tests/Builders/ProcessBuilderTests.cs
@@ -1,0 +1,66 @@
+using LinuxManager.Helpers;
+
+namespace LinuxManager.Tests.Builders;
+
+public class ProcessBuilderTests
+{
+    [Fact]
+    public void Constructor_SetsStartInfoFileName()
+    {
+        // Arrange / Act
+        using var process = new ProcessBuilder("cmd.exe").Build();
+
+        // Assert
+        process.StartInfo.FileName.Should().Be("cmd.exe");
+    }
+
+    [Fact]
+    public void Build_WithAllOptionsConfigured_PopulatesStartInfo()
+    {
+        // Arrange / Act
+        using var process = new ProcessBuilder("powershell.exe")
+            .SetArguments("/c echo hi")
+            .SetRedirectStandardOutput(true)
+            .SetRedirectStandardError(true)
+            .SetUseShellExecute(false)
+            .SetCreateNoWindow(true)
+            .SetVerb("runas")
+            .Build();
+
+        // Assert
+        process.StartInfo.FileName.Should().Be("powershell.exe");
+        process.StartInfo.Arguments.Should().Be("/c echo hi");
+        process.StartInfo.RedirectStandardOutput.Should().BeTrue();
+        process.StartInfo.RedirectStandardError.Should().BeTrue();
+        process.StartInfo.UseShellExecute.Should().BeFalse();
+        process.StartInfo.CreateNoWindow.Should().BeTrue();
+        process.StartInfo.Verb.Should().Be("runas");
+    }
+
+    [Fact]
+    public void SetterMethods_WhenCalled_ReturnSameBuilderForChaining()
+    {
+        // Arrange
+        var builder = new ProcessBuilder("cmd.exe");
+
+        // Act / Assert
+        builder.SetArguments("x").Should().BeSameAs(builder);
+        builder.SetRedirectStandardOutput(true).Should().BeSameAs(builder);
+        builder.SetRedirectStandardError(true).Should().BeSameAs(builder);
+        builder.SetUseShellExecute(false).Should().BeSameAs(builder);
+        builder.SetCreateNoWindow(true).Should().BeSameAs(builder);
+        builder.SetVerb("open").Should().BeSameAs(builder);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void SetUseShellExecute_StoresProvidedValue(bool value)
+    {
+        // Arrange / Act
+        using var process = new ProcessBuilder("cmd.exe").SetUseShellExecute(value).Build();
+
+        // Assert
+        process.StartInfo.UseShellExecute.Should().Be(value);
+    }
+}

--- a/LinuxManager.Tests/Core/FileServiceTests.cs
+++ b/LinuxManager.Tests/Core/FileServiceTests.cs
@@ -1,0 +1,125 @@
+using LinuxManager.Core.Contracts.Services;
+using LinuxManager.Core.Services;
+
+namespace LinuxManager.Tests.Core;
+
+/// <summary>
+/// Exercises <see cref="FileService"/> against a real, isolated temp directory.
+/// </summary>
+public class FileServiceTests : IDisposable
+{
+    private readonly string _root;
+    private readonly FileService _sut;
+
+    public FileServiceTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "lm-fileservice-" + Guid.NewGuid().ToString("N"));
+        _sut = new FileService();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    private sealed class Sample
+    {
+        public string Name { get; set; } = string.Empty;
+        public int Value { get; set; }
+    }
+
+    [Fact]
+    public void FileService_ImplementsIFileService()
+    {
+        // Assert
+        _sut.Should().BeAssignableTo<IFileService>();
+    }
+
+    [Fact]
+    public void Save_WhenFolderDoesNotExist_CreatesFolderAndWritesFile()
+    {
+        // Arrange
+        var content = new Sample { Name = "ubuntu", Value = 42 };
+
+        // Act
+        _sut.Save(_root, "data.json", content);
+
+        // Assert
+        Directory.Exists(_root).Should().BeTrue();
+        File.Exists(Path.Combine(_root, "data.json")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void SaveThenRead_RoundTripsContent()
+    {
+        // Arrange
+        var content = new Sample { Name = "debian", Value = 7 };
+        _sut.Save(_root, "roundtrip.json", content);
+
+        // Act
+        var result = _sut.Read<Sample>(_root, "roundtrip.json");
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Name.Should().Be("debian");
+        result.Value.Should().Be(7);
+    }
+
+    [Fact]
+    public void Read_WhenFileDoesNotExist_ReturnsDefaultForReferenceType()
+    {
+        // Act
+        var result = _sut.Read<Sample>(_root, "nope.json");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Read_WhenFileDoesNotExist_ReturnsDefaultForValueType()
+    {
+        // Act
+        var result = _sut.Read<int>(_root, "nope.json");
+
+        // Assert
+        result.Should().Be(0);
+    }
+
+    [Fact]
+    public void Delete_WhenFileExists_RemovesFile()
+    {
+        // Arrange
+        _sut.Save(_root, "todelete.json", new Sample());
+        var path = Path.Combine(_root, "todelete.json");
+        File.Exists(path).Should().BeTrue();
+
+        // Act
+        _sut.Delete(_root, "todelete.json");
+
+        // Assert
+        File.Exists(path).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Delete_WhenFileNameIsNull_DoesNotThrow()
+    {
+        // Act
+        Action act = () => _sut.Delete(_root, null!);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Delete_WhenFileDoesNotExist_DoesNotThrow()
+    {
+        // Act
+        Action act = () => _sut.Delete(_root, "ghost.json");
+
+        // Assert
+        act.Should().NotThrow();
+    }
+}

--- a/LinuxManager.Tests/Enums/SnapshotTypeTests.cs
+++ b/LinuxManager.Tests/Enums/SnapshotTypeTests.cs
@@ -1,0 +1,28 @@
+using LinuxManager.Enums;
+
+namespace LinuxManager.Tests.Enums;
+
+public class SnapshotTypeTests
+{
+    [Fact]
+    public void SnapshotType_DeclaresExpectedMembers()
+    {
+        // Arrange / Act
+        var names = Enum.GetNames<SnapshotType>();
+
+        // Assert
+        names.Should().BeEquivalentTo("Vhdx", "Archive");
+    }
+
+    [Theory]
+    [InlineData(SnapshotType.Vhdx, "Vhdx")]
+    [InlineData(SnapshotType.Archive, "Archive")]
+    public void ToString_ReturnsMemberName(SnapshotType type, string expected)
+    {
+        // Arrange / Act
+        var result = type.ToString();
+
+        // Assert
+        result.Should().Be(expected);
+    }
+}

--- a/LinuxManager.Tests/Exceptions/CustomExceptionsTests.cs
+++ b/LinuxManager.Tests/Exceptions/CustomExceptionsTests.cs
@@ -1,0 +1,63 @@
+using LinuxManager.Exceptions;
+
+namespace LinuxManager.Tests.Exceptions;
+
+public class CustomExceptionsTests
+{
+    [Fact]
+    public void GzFileExtractionException_DefaultConstructor_CreatesException()
+    {
+        // Arrange / Act
+        var ex = new GzFileExtractionException();
+
+        // Assert
+        ex.Should().BeAssignableTo<Exception>();
+    }
+
+    [Fact]
+    public void GzFileExtractionException_WithMessage_SetsMessage()
+    {
+        // Arrange / Act
+        var ex = new GzFileExtractionException("extraction failed");
+
+        // Assert
+        ex.Message.Should().Be("extraction failed");
+    }
+
+    [Fact]
+    public void FileCompressionException_WithMessage_SetsMessage()
+    {
+        // Arrange / Act
+        var ex = new FileCompressionException("compression failed");
+
+        // Assert
+        ex.Should().BeAssignableTo<Exception>();
+        ex.Message.Should().Be("compression failed");
+    }
+
+    [Fact]
+    public void ImportDistributionException_WithMessage_SetsMessage()
+    {
+        // Arrange / Act
+        var ex = new ImportDistributionException("import failed");
+
+        // Assert
+        ex.Should().BeAssignableTo<Exception>();
+        ex.Message.Should().Be("import failed");
+    }
+
+    [Fact]
+    public void Exceptions_DefaultConstructors_DoNotThrow()
+    {
+        // Arrange / Act
+        Action act = () =>
+        {
+            _ = new GzFileExtractionException();
+            _ = new FileCompressionException();
+            _ = new ImportDistributionException();
+        };
+
+        // Assert
+        act.Should().NotThrow();
+    }
+}

--- a/LinuxManager.Tests/Helpers/ArchiveHelperTests.cs
+++ b/LinuxManager.Tests/Helpers/ArchiveHelperTests.cs
@@ -1,0 +1,95 @@
+using System.IO.Compression;
+using System.Text;
+using LinuxManager.Helpers;
+
+namespace LinuxManager.Tests.Helpers;
+
+/// <summary>
+/// Exercises <see cref="ArchiveHelper"/> against a real, isolated temp directory.
+/// </summary>
+public class ArchiveHelperTests : IDisposable
+{
+    private readonly string _root;
+
+    public ArchiveHelperTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "lm-archive-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task DecompressArchive_WithValidGzip_DecompressesAndRemovesSource()
+    {
+        // Arrange
+        const string original = "archive payload contents";
+        var sourcePath = Path.Combine(_root, "image.tar.gz");
+        await using (var fs = File.Create(sourcePath))
+        await using (var gz = new GZipStream(fs, CompressionMode.Compress))
+        {
+            var bytes = Encoding.UTF8.GetBytes(original);
+            gz.Write(bytes, 0, bytes.Length);
+        }
+
+        // Act
+        var resultPath = await ArchiveHelper.DecompressArchive(sourcePath);
+
+        // Assert
+        resultPath.Should().Be(Path.Combine(_root, "image.tar"));
+        File.Exists(resultPath).Should().BeTrue();
+        File.Exists(sourcePath).Should().BeFalse("the source .gz is deleted after decompression");
+        (await File.ReadAllTextAsync(resultPath!)).Should().Be(original);
+    }
+
+    [Fact]
+    public async Task DecompressArchive_WhenFileMissing_ReturnsNull()
+    {
+        // Arrange
+        var missing = Path.Combine(_root, "missing.tar.gz");
+
+        // Act
+        var result = await ArchiveHelper.DecompressArchive(missing);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task MergeArchive_WithMultipleTars_StripsEofMarkerFromAllButLast()
+    {
+        // Arrange - two 2048-byte "tar" files; the EOF marker (1024 bytes) is stripped from all but the last
+        var tar0 = Path.Combine(_root, "layer0.tar");
+        var tar1 = Path.Combine(_root, "layer1.tar");
+        File.WriteAllBytes(tar0, new byte[2048]);
+        File.WriteAllBytes(tar1, new byte[2048]);
+        var dest = Path.Combine(_root, "merged.tar");
+
+        // Act
+        await ArchiveHelper.MergeArchive(new List<string> { tar0, tar1 }, dest);
+
+        // Assert - (2048 - 1024) + 2048
+        new FileInfo(dest).Length.Should().Be(3072);
+    }
+
+    [Fact]
+    public async Task MergeArchive_WithSingleTar_CopiesItWhole()
+    {
+        // Arrange
+        var tar = Path.Combine(_root, "only.tar");
+        File.WriteAllBytes(tar, new byte[2048]);
+        var dest = Path.Combine(_root, "merged-single.tar");
+
+        // Act
+        await ArchiveHelper.MergeArchive(new List<string> { tar }, dest);
+
+        // Assert - the single (last) file is copied in full, no marker stripped
+        new FileInfo(dest).Length.Should().Be(2048);
+    }
+}

--- a/LinuxManager.Tests/Helpers/FilesHelperTests.cs
+++ b/LinuxManager.Tests/Helpers/FilesHelperTests.cs
@@ -1,0 +1,149 @@
+using System.IO.Compression;
+using System.Text;
+using LinuxManager.Exceptions;
+using LinuxManager.Helpers;
+
+namespace LinuxManager.Tests.Helpers;
+
+/// <summary>
+/// Exercises <see cref="FilesHelper"/> against a real, isolated temp directory that is
+/// removed after each test, so the file-system side effects stay deterministic and contained.
+/// </summary>
+public class FilesHelperTests : IDisposable
+{
+    private readonly string _root;
+
+    public FilesHelperTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "lm-files-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CreateDirectory_WhenDirectoryDoesNotExist_CreatesItAndReturnsPath()
+    {
+        // Arrange
+        var expected = Path.Combine(_root, "newdir");
+
+        // Act
+        var result = FilesHelper.CreateDirectory(_root, "newdir");
+
+        // Assert
+        result.Should().Be(expected);
+        Directory.Exists(expected).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CreateDirectory_WhenDirectoryAlreadyExists_ReturnsPathWithoutThrowing()
+    {
+        // Arrange
+        FilesHelper.CreateDirectory(_root, "dup");
+
+        // Act
+        var result = FilesHelper.CreateDirectory(_root, "dup");
+
+        // Assert
+        result.Should().Be(Path.Combine(_root, "dup"));
+    }
+
+    [Fact]
+    public void CreateDirectory_WhenNameIsInvalid_ReturnsNull()
+    {
+        // Arrange - a null character is an illegal path character on every platform
+        var invalidName = "bad\0name";
+
+        // Act
+        var result = FilesHelper.CreateDirectory(_root, invalidName);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void RemoveDirectory_WhenDirectoryIsEmpty_DeletesIt()
+    {
+        // Arrange
+        var dir = Path.Combine(_root, "to-remove");
+        Directory.CreateDirectory(dir);
+
+        // Act
+        FilesHelper.RemoveDirectory(dir);
+
+        // Assert
+        Directory.Exists(dir).Should().BeFalse();
+    }
+
+    [Fact]
+    public void RemoveDirectory_WhenDirectoryMissing_DoesNotThrow()
+    {
+        // Arrange
+        var dir = Path.Combine(_root, "does-not-exist");
+
+        // Act
+        Action act = () => FilesHelper.RemoveDirectory(dir);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void RemoveDirContent_RemovesFilesAndEmptySubDirectories()
+    {
+        // Arrange
+        var dir = Path.Combine(_root, "with-content");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "file1.txt"), "data");
+        Directory.CreateDirectory(Path.Combine(dir, "emptysub"));
+
+        // Act
+        FilesHelper.RemoveDirContent(dir);
+
+        // Assert
+        Directory.EnumerateFiles(dir).Should().BeEmpty();
+        Directory.EnumerateDirectories(dir).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractGzFile_WithValidGzip_WritesDecompressedContent()
+    {
+        // Arrange
+        const string original = "the quick brown fox";
+        var sourceGz = Path.Combine(_root, "source.gz");
+        var dest = Path.Combine(_root, "extracted.txt");
+        await using (var fs = File.Create(sourceGz))
+        await using (var gz = new GZipStream(fs, CompressionMode.Compress))
+        {
+            var bytes = Encoding.UTF8.GetBytes(original);
+            gz.Write(bytes, 0, bytes.Length);
+        }
+
+        // Act
+        await FilesHelper.ExtractGzFile(sourceGz, dest);
+
+        // Assert
+        File.Exists(dest).Should().BeTrue();
+        (await File.ReadAllTextAsync(dest)).Should().Be(original);
+    }
+
+    [Fact]
+    public async Task ExtractGzFile_WhenSourceMissing_ThrowsGzFileExtractionException()
+    {
+        // Arrange
+        var missing = Path.Combine(_root, "missing.gz");
+        var dest = Path.Combine(_root, "out.txt");
+
+        // Act
+        Func<Task> act = () => FilesHelper.ExtractGzFile(missing, dest);
+
+        // Assert
+        await act.Should().ThrowAsync<GzFileExtractionException>();
+    }
+}

--- a/LinuxManager.Tests/Helpers/RuntimeHelperTests.cs
+++ b/LinuxManager.Tests/Helpers/RuntimeHelperTests.cs
@@ -1,0 +1,27 @@
+using LinuxManager.Helpers;
+
+namespace LinuxManager.Tests.Helpers;
+
+public class RuntimeHelperTests
+{
+    [Fact]
+    public void IsMSIX_WhenRunningUnpackaged_ReturnsFalse()
+    {
+        // Arrange / Act - the xUnit test host is never a packaged (MSIX) application,
+        // so GetCurrentPackageFullName reports APPMODEL_ERROR_NO_PACKAGE.
+        var result = RuntimeHelper.IsMSIX;
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsMSIX_WhenAccessed_DoesNotThrow()
+    {
+        // Arrange / Act
+        Action act = () => _ = RuntimeHelper.IsMSIX;
+
+        // Assert
+        act.Should().NotThrow();
+    }
+}

--- a/LinuxManager.Tests/Helpers/TextInputValidationTests.cs
+++ b/LinuxManager.Tests/Helpers/TextInputValidationTests.cs
@@ -1,0 +1,165 @@
+using System.Text.RegularExpressions;
+using LinuxManager.Helpers;
+
+namespace LinuxManager.Tests.Helpers;
+
+public class TextInputValidationTests
+{
+    [Fact]
+    public void NotNullOrWhiteSpace_WithNonEmptyText_ReturnsSameInstance()
+    {
+        // Arrange
+        var sut = new TextInputValidation("Ubuntu");
+
+        // Act
+        var result = sut.NotNullOrWhiteSpace();
+
+        // Assert
+        result.Should().BeSameAs(sut);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NotNullOrWhiteSpace_WithNullOrWhiteSpace_ThrowsArgumentException(string? input)
+    {
+        // Arrange
+        var sut = new TextInputValidation(input!);
+
+        // Act
+        Action act = () => sut.NotNullOrWhiteSpace();
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*cannot be empty*");
+    }
+
+    [Fact]
+    public void IncludeWhiteSpaceChar_WhenTextContainsWhiteSpace_ThrowsArgumentException()
+    {
+        // Arrange
+        var sut = new TextInputValidation("my distro");
+
+        // Act
+        Action act = () => sut.IncludeWhiteSpaceChar();
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*cannot include white spaces*");
+    }
+
+    [Fact]
+    public void IncludeWhiteSpaceChar_WhenTextHasNoWhiteSpace_ReturnsSameInstance()
+    {
+        // Arrange
+        var sut = new TextInputValidation("mydistro");
+
+        // Act
+        var result = sut.IncludeWhiteSpaceChar();
+
+        // Assert
+        result.Should().BeSameAs(sut);
+    }
+
+    [Theory]
+    [InlineData("abc", 3)]   // exactly minimum length (boundary)
+    [InlineData("abcd", 3)]  // above minimum
+    public void MinimumLength_WhenLengthMeetsMinimum_ReturnsSameInstance(string input, int minLength)
+    {
+        // Arrange
+        var sut = new TextInputValidation(input);
+
+        // Act
+        var result = sut.MinimumLength(minLength);
+
+        // Assert
+        result.Should().BeSameAs(sut);
+    }
+
+    [Fact]
+    public void MinimumLength_WhenShorterThanMinimum_ThrowsArgumentException()
+    {
+        // Arrange
+        var sut = new TextInputValidation("ab");
+
+        // Act
+        Action act = () => sut.MinimumLength(3);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*at least 3 characters*");
+    }
+
+    [Fact]
+    public void InvalidCharacters_WhenInputMatchesAllowedPattern_ReturnsSameInstance()
+    {
+        // Arrange
+        var sut = new TextInputValidation("Ubuntu22");
+        var regex = new Regex("^[a-zA-Z0-9]+$");
+
+        // Act
+        var result = sut.InvalidCharacters(regex, "special characters");
+
+        // Assert
+        result.Should().BeSameAs(sut);
+    }
+
+    [Fact]
+    public void InvalidCharacters_WhenInputDoesNotMatchAllowedPattern_ThrowsArgumentException()
+    {
+        // Arrange
+        var sut = new TextInputValidation("Ubuntu@22");
+        var regex = new Regex("^[a-zA-Z0-9]+$");
+
+        // Act
+        Action act = () => sut.InvalidCharacters(regex, "special characters");
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*cannot include special characters*");
+    }
+
+    [Fact]
+    public void DataAlreadyExist_WhenCollectionContainsValueCaseInsensitive_ThrowsArgumentException()
+    {
+        // Arrange
+        var sut = new TextInputValidation("ubuntu");
+        var existing = new List<string> { "Ubuntu", "Debian" };
+
+        // Act
+        Action act = () => sut.DataAlreadyExist(existing);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*already exists*");
+    }
+
+    [Fact]
+    public void DataAlreadyExist_WhenCollectionDoesNotContainValue_ReturnsSameInstance()
+    {
+        // Arrange
+        var sut = new TextInputValidation("Fedora");
+        var existing = new List<string> { "Ubuntu", "Debian" };
+
+        // Act
+        var result = sut.DataAlreadyExist(existing);
+
+        // Assert
+        result.Should().BeSameAs(sut);
+    }
+
+    [Fact]
+    public void Validators_WhenChainedOnValidInput_AllPassAndReturnSameInstance()
+    {
+        // Arrange
+        var sut = new TextInputValidation("Ubuntu");
+        var existing = new List<string> { "Debian" };
+
+        // Act
+        var result = sut
+            .NotNullOrWhiteSpace()
+            .IncludeWhiteSpaceChar()
+            .MinimumLength(2)
+            .InvalidCharacters(new Regex("^[a-zA-Z0-9]+$"), "special characters")
+            .DataAlreadyExist(existing);
+
+        // Assert
+        result.Should().BeSameAs(sut);
+    }
+}

--- a/LinuxManager.Tests/Helpers/UnitHelperTests.cs
+++ b/LinuxManager.Tests/Helpers/UnitHelperTests.cs
@@ -1,0 +1,76 @@
+using LinuxManager.Helpers;
+
+namespace LinuxManager.Tests.Helpers;
+
+public class UnitHelperTests
+{
+    [Theory]
+    [InlineData(0L, "0")]
+    [InlineData(1073741824L, "1")]            // exactly 1 GiB
+    [InlineData(1610612736L, "1.5")]          // 1.5 GiB
+    [InlineData(536870912L, "0.5")]           // 0.5 GiB
+    public void ParseBytesToGigaBytesStr_ForVariousByteCounts_ReturnsRoundedInvariantString(long bytes, string expected)
+    {
+        // Arrange / Act
+        var result = UnitHelper.ParseBytesToGigaBytesStr(bytes);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void ParseBytesToGigaBytesStr_WhenValueHasManyDecimals_RoundsToTwoDecimals()
+    {
+        // Arrange - 1.234567 GiB worth of bytes
+        var bytes = (long)(1.234567 * 1024 * 1024 * 1024);
+
+        // Act
+        var result = UnitHelper.ParseBytesToGigaBytesStr(bytes);
+
+        // Assert
+        result.Should().Be("1.23");
+    }
+
+    [Theory]
+    [InlineData(0L, 0.0)]
+    [InlineData(1073741824L, 1.0)]
+    [InlineData(1610612736L, 1.5)]
+    [InlineData(536870912L, 0.5)]
+    public void BytesToGigaBytesStr_ForVariousByteCounts_ReturnsRoundedDouble(long bytes, double expected)
+    {
+        // Arrange / Act
+        var result = UnitHelper.BytesToGigaBytesStr(bytes);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("50", "100", "50")]
+    [InlineData("1", "3", "33.33")]
+    [InlineData("0", "100", "0")]
+    [InlineData("100", "100", "100")]
+    [InlineData("1.5", "3", "50")]
+    public void CalculateAndParsePercentage_WithValidNumbers_ReturnsRoundedPercentage(string part, string total, string expected)
+    {
+        // Arrange / Act
+        var result = UnitHelper.CalculateAndParsePercentage(part, total);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("5", "0")]      // division by zero guard
+    [InlineData("abc", "100")]  // non-numeric part
+    [InlineData("50", "xyz")]   // non-numeric total
+    [InlineData("", "")]        // empty inputs
+    public void CalculateAndParsePercentage_WithInvalidOrZeroInputs_ReturnsZeroString(string part, string total)
+    {
+        // Arrange / Act
+        var result = UnitHelper.CalculateAndParsePercentage(part, total);
+
+        // Assert
+        result.Should().Be("0");
+    }
+}

--- a/LinuxManager.Tests/Helpers/WslImageHelperTests.cs
+++ b/LinuxManager.Tests/Helpers/WslImageHelperTests.cs
@@ -1,0 +1,30 @@
+using LinuxManager.Helpers;
+
+namespace LinuxManager.Tests.Helpers;
+
+public class WslImageHelperTests
+{
+    [Fact]
+    public void Constructor_WithAnyPath_DoesNotThrow()
+    {
+        // Arrange / Act
+        Action act = () => _ = new WslImageHelper(@"C:\does\not\exist.vhdx");
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ReadFile_WhenVhdxImageDoesNotExist_Throws()
+    {
+        // Arrange
+        var missingImage = Path.Combine(Path.GetTempPath(), "missing-" + Guid.NewGuid().ToString("N") + ".vhdx");
+        var sut = new WslImageHelper(missingImage);
+
+        // Act
+        Action act = () => sut.ReadFile("/etc/os-release");
+
+        // Assert
+        act.Should().Throw<Exception>();
+    }
+}

--- a/LinuxManager.Tests/LinuxManager.Tests.csproj
+++ b/LinuxManager.Tests/LinuxManager.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <Platforms>x64</Platforms>
+    <PlatformTarget>x64</PlatformTarget>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <EnableMsixTooling>true</EnableMsixTooling>
+    <!-- The production helpers under test are pure logic; the WinUI runtime is never
+         initialised by these tests, so a self-contained Windows App SDK host is not required. -->
+    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LinuxManager\Linux Manager.csproj" />
+    <ProjectReference Include="..\LinuxManager.Core\LinuxManager.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/LinuxManager.Tests/Models/DiskUsageInfoTests.cs
+++ b/LinuxManager.Tests/Models/DiskUsageInfoTests.cs
@@ -1,0 +1,38 @@
+using LinuxManager.Models;
+
+namespace LinuxManager.Tests.Models;
+
+public class DiskUsageInfoTests
+{
+    [Fact]
+    public void NewDiskUsageInfo_DefaultsAllPropertiesToEmptyString()
+    {
+        // Arrange / Act
+        var info = new DiskUsageInfo();
+
+        // Assert
+        info.Size.Should().BeEmpty();
+        info.Used.Should().BeEmpty();
+        info.Available.Should().BeEmpty();
+        info.UsePercentage.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Properties_WhenAssigned_ReturnAssignedValues()
+    {
+        // Arrange / Act
+        var info = new DiskUsageInfo
+        {
+            Size = "100G",
+            Used = "50G",
+            Available = "50G",
+            UsePercentage = "50%",
+        };
+
+        // Assert
+        info.Size.Should().Be("100G");
+        info.Used.Should().Be("50G");
+        info.Available.Should().Be("50G");
+        info.UsePercentage.Should().Be("50%");
+    }
+}

--- a/LinuxManager.Tests/Models/DistributionTests.cs
+++ b/LinuxManager.Tests/Models/DistributionTests.cs
@@ -1,0 +1,91 @@
+using System.ComponentModel;
+using LinuxManager.Contracts.Models;
+using LinuxManager.Models;
+
+namespace LinuxManager.Tests.Models;
+
+public class DistributionTests
+{
+    [Fact]
+    public void NewDistribution_HasInitializedCollectionsAndDefaults()
+    {
+        // Arrange / Act
+        var distro = new Distribution();
+
+        // Assert
+        distro.Users.Should().NotBeNull().And.BeEmpty();
+        distro.Snapshots.Should().NotBeNull().And.BeEmpty();
+        distro.RunningProcesses.Should().NotBeNull().And.BeEmpty();
+        distro.SnapshotsTotalSize.Should().Be("0.0");
+    }
+
+    [Fact]
+    public void Distribution_ImplementsExpectedContracts()
+    {
+        // Arrange / Act
+        var distro = new Distribution();
+
+        // Assert
+        distro.Should().BeAssignableTo<INotifyPropertyChanged>();
+        distro.Should().BeAssignableTo<IBaseModel>();
+    }
+
+    [Fact]
+    public void Name_WhenSet_RaisesPropertyChangedWithPropertyName()
+    {
+        // Arrange
+        var distro = new Distribution();
+        var raised = new List<string?>();
+        distro.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        // Act
+        distro.Name = "Ubuntu";
+
+        // Assert
+        distro.Name.Should().Be("Ubuntu");
+        raised.Should().ContainSingle().Which.Should().Be(nameof(Distribution.Name));
+    }
+
+    [Fact]
+    public void SnapshotsTotalSize_WhenSet_RaisesPropertyChangedWithPropertyName()
+    {
+        // Arrange
+        var distro = new Distribution();
+        string? changed = null;
+        distro.PropertyChanged += (_, e) => changed = e.PropertyName;
+
+        // Act
+        distro.SnapshotsTotalSize = "12.5";
+
+        // Assert
+        distro.SnapshotsTotalSize.Should().Be("12.5");
+        changed.Should().Be(nameof(Distribution.SnapshotsTotalSize));
+    }
+
+    [Fact]
+    public void Properties_WhenAssigned_ReturnAssignedValues()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var diskUsage = new DiskUsageInfo { Used = "10G" };
+
+        // Act
+        var distro = new Distribution
+        {
+            Id = id,
+            Path = @"C:\wsl\ubuntu",
+            WslVersion = 2,
+            OsName = "Ubuntu",
+            OsVersion = "22.04",
+            DiskUsageInfo = diskUsage,
+        };
+
+        // Assert
+        distro.Id.Should().Be(id);
+        distro.Path.Should().Be(@"C:\wsl\ubuntu");
+        distro.WslVersion.Should().Be(2);
+        distro.OsName.Should().Be("Ubuntu");
+        distro.OsVersion.Should().Be("22.04");
+        distro.DiskUsageInfo.Should().BeSameAs(diskUsage);
+    }
+}

--- a/LinuxManager.Tests/Models/Docker/AuthTokenTests.cs
+++ b/LinuxManager.Tests/Models/Docker/AuthTokenTests.cs
@@ -1,0 +1,48 @@
+using LinuxManager.Models.Docker;
+using Newtonsoft.Json;
+
+namespace LinuxManager.Tests.Models.Docker;
+
+public class AuthTokenTests
+{
+    [Fact]
+    public void Properties_WhenAssigned_ReturnAssignedValues()
+    {
+        // Arrange / Act
+        var token = new AuthToken
+        {
+            Token = "abc",
+            AccessToken = "def",
+            ExpiresIn = 300,
+        };
+
+        // Assert
+        token.Token.Should().Be("abc");
+        token.AccessToken.Should().Be("def");
+        token.ExpiresIn.Should().Be(300);
+    }
+
+    [Fact]
+    public void Deserialize_MapsSnakeCaseJsonPropertiesViaAttributes()
+    {
+        // Arrange
+        const string json = """
+        {
+            "token": "header.payload.signature",
+            "access_token": "access-123",
+            "expires_in": 300,
+            "issued_at": "2026-06-13T10:00:00Z"
+        }
+        """;
+
+        // Act
+        var token = JsonConvert.DeserializeObject<AuthToken>(json);
+
+        // Assert
+        token.Should().NotBeNull();
+        token!.Token.Should().Be("header.payload.signature");
+        token.AccessToken.Should().Be("access-123");
+        token.ExpiresIn.Should().Be(300);
+        token.IssuedAt.UtcDateTime.Should().Be(new DateTime(2026, 6, 13, 10, 0, 0, DateTimeKind.Utc));
+    }
+}

--- a/LinuxManager.Tests/Models/Docker/DockerImageManifestTests.cs
+++ b/LinuxManager.Tests/Models/Docker/DockerImageManifestTests.cs
@@ -1,0 +1,69 @@
+using LinuxManager.Models.Docker.Manifests;
+using Newtonsoft.Json;
+
+namespace LinuxManager.Tests.Models.Docker;
+
+public class DockerImageManifestTests
+{
+    [Fact]
+    public void GetLayers_ReturnsDigestOfEveryLayer()
+    {
+        // Arrange
+        var sut = new DockerImageManifest
+        {
+            Layers = new List<Config>
+            {
+                new() { Digest = "sha256:l1" },
+                new() { Digest = "sha256:l2" },
+            },
+        };
+
+        // Act
+        var layers = sut.GetLayers();
+
+        // Assert
+        layers.Should().Equal("sha256:l1", "sha256:l2");
+    }
+
+    [Fact]
+    public void GetLayers_WhenNoLayers_ReturnsEmptyList()
+    {
+        // Arrange
+        var sut = new DockerImageManifest { Layers = new List<Config>() };
+
+        // Act
+        var layers = sut.GetLayers();
+
+        // Assert
+        layers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Deserialize_MapsJsonPropertiesViaAttributes()
+    {
+        // Arrange
+        const string json = """
+        {
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "config": { "mediaType": "cfg", "size": 7023, "digest": "sha256:config" },
+            "layers": [
+                { "mediaType": "lay", "size": 2812, "digest": "sha256:layer1" }
+            ]
+        }
+        """;
+
+        // Act
+        var manifest = JsonConvert.DeserializeObject<DockerImageManifest>(json);
+
+        // Assert
+        manifest.Should().NotBeNull();
+        manifest!.SchemaVersion.Should().Be(2);
+        manifest.MediaType.Should().Be("application/vnd.docker.distribution.manifest.v2+json");
+        manifest.Config.Digest.Should().Be("sha256:config");
+        manifest.Config.Size.Should().Be(7023);
+        manifest.Layers.Should().ContainSingle();
+        manifest.Layers[0].Digest.Should().Be("sha256:layer1");
+        manifest.GetLayers().Should().Equal("sha256:layer1");
+    }
+}

--- a/LinuxManager.Tests/Models/Docker/ImageFatManifestTests.cs
+++ b/LinuxManager.Tests/Models/Docker/ImageFatManifestTests.cs
@@ -1,0 +1,87 @@
+using LinuxManager.Models.Docker.Manifests;
+using Newtonsoft.Json;
+
+namespace LinuxManager.Tests.Models.Docker;
+
+public class ImageFatManifestTests
+{
+    private static ImageFatManifest BuildSample() => new()
+    {
+        SchemaVersion = 2,
+        MediaType = "application/vnd.docker.distribution.manifest.list.v2+json",
+        Manifests = new List<Manifest>
+        {
+            new() { Digest = "sha256:amd", Platform = new Platform { Architecture = "amd64", Os = "linux" } },
+            new() { Digest = "sha256:arm", Platform = new Platform { Architecture = "arm64", Os = "linux" } },
+        },
+    };
+
+    [Fact]
+    public void GetLayers_ReturnsDigestOfEveryManifest()
+    {
+        // Arrange
+        var sut = BuildSample();
+
+        // Act
+        var layers = sut.GetLayers();
+
+        // Assert
+        layers.Should().Equal("sha256:amd", "sha256:arm");
+    }
+
+    [Fact]
+    public void GetManifestByArchitecture_WhenArchitectureExists_ReturnsMatchingDigest()
+    {
+        // Arrange
+        var sut = BuildSample();
+
+        // Act
+        var digest = sut.GetManifestByArchitecture("amd64");
+
+        // Assert
+        digest.Should().Be("sha256:amd");
+    }
+
+    [Fact]
+    public void GetManifestByArchitecture_WhenArchitectureMissing_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var sut = BuildSample();
+
+        // Act
+        Action act = () => sut.GetManifestByArchitecture("ppc64le");
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Deserialize_MapsJsonPropertiesViaAttributes()
+    {
+        // Arrange
+        const string json = """
+        {
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+            "manifests": [
+                { "digest": "sha256:abc", "mediaType": "m", "size": 525,
+                  "platform": { "architecture": "amd64", "os": "linux", "variant": "v8" } }
+            ]
+        }
+        """;
+
+        // Act
+        var manifest = JsonConvert.DeserializeObject<ImageFatManifest>(json);
+
+        // Assert
+        manifest.Should().NotBeNull();
+        manifest!.SchemaVersion.Should().Be(2);
+        manifest.MediaType.Should().Be("application/vnd.docker.distribution.manifest.list.v2+json");
+        manifest.Manifests.Should().ContainSingle();
+        manifest.Manifests[0].Digest.Should().Be("sha256:abc");
+        manifest.Manifests[0].Size.Should().Be(525);
+        manifest.Manifests[0].Platform.Architecture.Should().Be("amd64");
+        manifest.Manifests[0].Platform.Os.Should().Be("linux");
+        manifest.Manifests[0].Platform.Variant.Should().Be("v8");
+    }
+}

--- a/LinuxManager.Tests/Models/SnapshotTests.cs
+++ b/LinuxManager.Tests/Models/SnapshotTests.cs
@@ -1,0 +1,58 @@
+using LinuxManager.Contracts.Models;
+using LinuxManager.Enums;
+using LinuxManager.Models;
+
+namespace LinuxManager.Tests.Models;
+
+public class SnapshotTests
+{
+    [Fact]
+    public void NewSnapshot_DefaultsTypeToArchive()
+    {
+        // Arrange / Act
+        var snapshot = new Snapshot();
+
+        // Assert
+        snapshot.Type.Should().Be(SnapshotType.Archive.ToString());
+    }
+
+    [Fact]
+    public void Snapshot_ImplementsIBaseModel()
+    {
+        // Arrange / Act
+        var snapshot = new Snapshot();
+
+        // Assert
+        snapshot.Should().BeAssignableTo<IBaseModel>();
+    }
+
+    [Fact]
+    public void Properties_WhenAssigned_ReturnAssignedValues()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+
+        // Act
+        var snapshot = new Snapshot
+        {
+            Id = id,
+            Name = "Before upgrade",
+            Description = "snapshot description",
+            Type = SnapshotType.Vhdx.ToString(),
+            CreationDate = "2026-06-13",
+            Size = "1.2",
+            DistroSize = "3.4",
+            Path = @"C:\snapshots\snap.tar",
+        };
+
+        // Assert
+        snapshot.Id.Should().Be(id);
+        snapshot.Name.Should().Be("Before upgrade");
+        snapshot.Description.Should().Be("snapshot description");
+        snapshot.Type.Should().Be("Vhdx");
+        snapshot.CreationDate.Should().Be("2026-06-13");
+        snapshot.Size.Should().Be("1.2");
+        snapshot.DistroSize.Should().Be("3.4");
+        snapshot.Path.Should().Be(@"C:\snapshots\snap.tar");
+    }
+}

--- a/LinuxManager.Tests/Usings.cs
+++ b/LinuxManager.Tests/Usings.cs
@@ -1,0 +1,2 @@
+global using Xunit;
+global using FluentAssertions;

--- a/LinuxManager.Tests/Views/InvertBooleanTests.cs
+++ b/LinuxManager.Tests/Views/InvertBooleanTests.cs
@@ -1,0 +1,18 @@
+using LinuxManager.Views.Functions;
+
+namespace LinuxManager.Tests.Views;
+
+public class InvertBooleanTests
+{
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void Invert_ReturnsLogicalNegationOfInput(bool input, bool expected)
+    {
+        // Arrange / Act
+        var result = InvertBoolean.Invert(input);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+}

--- a/LinuxManager.sln
+++ b/LinuxManager.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Linux Manager", "LinuxManag
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LinuxManager.Core", "LinuxManager.Core\LinuxManager.Core.csproj", "{2051DBEA-6C56-4B46-8F2D-A10B14B41A61}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinuxManager.Tests", "LinuxManager.Tests\LinuxManager.Tests.csproj", "{1C4CCA74-E755-4791-9C2F-406D42B16352}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -59,6 +61,22 @@ Global
 		{2051DBEA-6C56-4B46-8F2D-A10B14B41A61}.Release|x64.Build.0 = Release|x64
 		{2051DBEA-6C56-4B46-8F2D-A10B14B41A61}.Release|x86.ActiveCfg = Release|x86
 		{2051DBEA-6C56-4B46-8F2D-A10B14B41A61}.Release|x86.Build.0 = Release|x86
+		{1C4CCA74-E755-4791-9C2F-406D42B16352}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{1C4CCA74-E755-4791-9C2F-406D42B16352}.Debug|Any CPU.Build.0 = Debug|x64
+		{1C4CCA74-E755-4791-9C2F-406D42B16352}.Debug|arm64.ActiveCfg = Debug|x64
+		{1C4CCA74-E755-4791-9C2F-406D42B16352}.Debug|arm64.Build.0 = Debug|x64
+		{1C4CCA74-E755-4791-9C2F-406D42B16352}.Debug|x64.ActiveCfg = Debug|x64
+		{1C4CCA74-E755-4791-9C2F-406D42B16352}.Debug|x64.Build.0 = Debug|x64
+		{1C4CCA74-E755-4791-9C2F-406D42B16352}.Debug|x86.ActiveCfg = Debug|x64
+		{1C4CCA74-E755-4791-9C2F-406D42B16352}.Debug|x86.Build.0 = Debug|x64
+		{1C4CCA74-E755-4791-9C2F-406D42B16352}.Release|Any CPU.ActiveCfg = Release|x64
+		{1C4CCA74-E755-4791-9C2F-406D42B16352}.Release|Any CPU.Build.0 = Release|x64
+		{1C4CCA74-E755-4791-9C2F-406D42B16352}.Release|arm64.ActiveCfg = Release|x64
+		{1C4CCA74-E755-4791-9C2F-406D42B16352}.Release|arm64.Build.0 = Release|x64
+		{1C4CCA74-E755-4791-9C2F-406D42B16352}.Release|x64.ActiveCfg = Release|x64
+		{1C4CCA74-E755-4791-9C2F-406D42B16352}.Release|x64.Build.0 = Release|x64
+		{1C4CCA74-E755-4791-9C2F-406D42B16352}.Release|x86.ActiveCfg = Release|x64
+		{1C4CCA74-E755-4791-9C2F-406D42B16352}.Release|x86.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/LinuxManager/Package.appxmanifest
+++ b/LinuxManager/Package.appxmanifest
@@ -51,7 +51,7 @@
 
           <com:Extension Category="windows.comServer">
               <com:ComServer>
-                  <com:ExeServer Executable="LinuxManager.exe" Arguments="----AppNotificationActivated:" DisplayName="Toast activator">
+                  <com:ExeServer Executable="Linux Manager.exe" Arguments="----AppNotificationActivated:" DisplayName="Toast activator">
                       <com:Class Id="083152C6-79F4-4B88-882E-A642ACCFAC48" DisplayName="Toast activator"/>
                   </com:ExeServer>
               </com:ComServer>


### PR DESCRIPTION
## Summary

Adds a unit test project and fixes a packaging-manifest bug found along the way.

## Unit tests — `LinuxManager.Tests`

New **xUnit + FluentAssertions** project — **94 tests, all green**:

```
dotnet test LinuxManager.Tests\LinuxManager.Tests.csproj -p:Platform=x64
```

It covers the genuinely unit-testable, pure-logic surface:

- **Helpers** — `UnitHelper`, `TextInputValidation`, `ProcessBuilder`, `FilesHelper`, `ArchiveHelper`, `WslImageHelper` (error path), `RuntimeHelper`
- **Builders** — `DistributionBuilder`
- **Models** — `Distribution` (incl. `INotifyPropertyChanged`), `Snapshot`, `DiskUsageInfo`
- **Docker** — `ImageFatManifest`, `DockerImageManifest`, `AuthToken` (incl. Newtonsoft JSON mapping)
- **Misc** — `InvertBoolean`, `SnapshotType`, custom exceptions
- **Core** — `LinuxManager.Core.FileService` (real temp-dir round trips)

The test project references the WinUI app assembly but never initializes the WinUI runtime, so the pure static helpers run cleanly under the xUnit host. The project is registered in `LinuxManager.sln`.

## Manifest fix — `Package.appxmanifest`

The toast `com:ExeServer` executable was `LinuxManager.exe`, but the actual build output is `Linux Manager.exe` (with a space). Corrected so COM/toast activation won't fail with `REGDB_E_CLASSNOTREG`.

## Out of scope (intentionally not unit-tested)

UI / integration code that requires a live WSL / Docker / Windows environment — `WslHelper`, `DockerHelper`, all Services / ViewModels / Views, activation & navigation. These are integration-level and would need interface extraction around the process/HTTP/WSL boundaries to unit test; left for a follow-up.

## Test plan

- `dotnet test LinuxManager.Tests\LinuxManager.Tests.csproj -p:Platform=x64` → **94 passed, 0 failed**.
- Full solution builds clean (`Debug | x64`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
