### PR TITLE
Fix SharpCompress Dependabot vulnerability (remove unused package)

### DIFF
--- a/LinuxManager/Linux Manager.csproj
+++ b/LinuxManager/Linux Manager.csproj
@@ -154,7 +154,6 @@
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="SharpCompress" Version="0.35.0" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.50.0.58025">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## What
Removes the `SharpCompress` 0.35.0 dependency, flagged by Dependabot / `NU1902` (advisory **GHSA-6c8g-7p36-r338**, moderate).

## Why this is safe
`SharpCompress` was a direct `PackageReference` but is **not referenced anywhere** in the codebase — archiving uses `System.IO.Compression` (`GZipStream`) and `SharpZipLib`. `dotnet nuget why` confirms nothing depends on it transitively. Removing it eliminates the vulnerability with zero behavioural change, mirroring the repo''s earlier DotNetZip removal.

## Verification
- ✅ `LinuxManager.sln` builds (Release|x64)
- ✅ 94/94 tests green
- ✅ `NU1902` SharpCompress warning gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)