### PR TITLE
Refactor: centralise process creation behaviour via ProcessFactory

### DIFF
--- a/LinuxManager.Tests/Builders/ProcessFactoryTests.cs
+++ b/LinuxManager.Tests/Builders/ProcessFactoryTests.cs
@@ -1,0 +1,104 @@
+using LinuxManager.Helpers;
+
+namespace LinuxManager.Tests.Builders;
+
+public class ProcessFactoryTests
+{
+    [Fact]
+    public void Create_SetsFileNameAndArguments()
+    {
+        // Arrange / Act
+        using var process = ProcessFactory.Create(ProcessType.Background, "cmd.exe", "/c echo hi");
+
+        // Assert
+        process.StartInfo.FileName.Should().Be("cmd.exe");
+        process.StartInfo.Arguments.Should().Be("/c echo hi");
+    }
+
+    [Fact]
+    public void Create_WithoutArguments_LeavesArgumentsEmpty()
+    {
+        // Arrange / Act
+        using var process = ProcessFactory.Create(ProcessType.Default, "explorer.exe");
+
+        // Assert
+        process.StartInfo.Arguments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Create_ReadOutput_CapturesStdoutOnlyAndHidesWindow()
+    {
+        using var process = ProcessFactory.Create(ProcessType.ReadOutput, "cmd.exe", "/c wsl --list");
+
+        process.StartInfo.UseShellExecute.Should().BeFalse();
+        process.StartInfo.RedirectStandardOutput.Should().BeTrue();
+        process.StartInfo.RedirectStandardError.Should().BeFalse();
+        process.StartInfo.CreateNoWindow.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Create_ReadOutputAndError_CapturesBothStreamsAndHidesWindow()
+    {
+        using var process = ProcessFactory.Create(ProcessType.ReadOutputAndError, "powershell.exe", "/c x");
+
+        process.StartInfo.UseShellExecute.Should().BeFalse();
+        process.StartInfo.RedirectStandardOutput.Should().BeTrue();
+        process.StartInfo.RedirectStandardError.Should().BeTrue();
+        process.StartInfo.CreateNoWindow.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Create_Background_HidesWindowWithoutRedirectingStreams()
+    {
+        using var process = ProcessFactory.Create(ProcessType.Background, "cmd.exe", "/c wsl --shutdown");
+
+        process.StartInfo.UseShellExecute.Should().BeFalse();
+        process.StartInfo.RedirectStandardOutput.Should().BeFalse();
+        process.StartInfo.RedirectStandardError.Should().BeFalse();
+        process.StartInfo.CreateNoWindow.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Create_Interactive_UsesShellExecuteWithNoWindowFlag()
+    {
+        using var process = ProcessFactory.Create(ProcessType.Interactive, "cmd.exe", "/c wsl ~");
+
+        process.StartInfo.UseShellExecute.Should().BeTrue();
+        process.StartInfo.RedirectStandardOutput.Should().BeFalse();
+        process.StartInfo.CreateNoWindow.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Create_Elevated_UsesShellExecuteWithRunAsVerb()
+    {
+        using var process = ProcessFactory.Create(ProcessType.Elevated, "powershell.exe", "/c winget install x");
+
+        process.StartInfo.UseShellExecute.Should().BeTrue();
+        process.StartInfo.Verb.Should().Be("runas");
+    }
+
+    [Fact]
+    public void Create_Default_LeavesFrameworkDefaults()
+    {
+        using var process = ProcessFactory.Create(ProcessType.Default, "explorer.exe", @"\\wsl$\Ubuntu");
+
+        process.StartInfo.UseShellExecute.Should().BeFalse();
+        process.StartInfo.RedirectStandardOutput.Should().BeFalse();
+        process.StartInfo.RedirectStandardError.Should().BeFalse();
+        process.StartInfo.CreateNoWindow.Should().BeFalse();
+        process.StartInfo.Verb.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Create_WithUnsupportedType_Throws()
+    {
+        // Arrange
+        var invalid = (ProcessType)999;
+
+        // Act
+        var act = () => ProcessFactory.Create(invalid, "cmd.exe");
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/LinuxManager/Builders/ProcessFactory.cs
+++ b/LinuxManager/Builders/ProcessFactory.cs
@@ -1,0 +1,71 @@
+using System.Diagnostics;
+
+namespace LinuxManager.Helpers;
+
+/// <summary>
+/// Centralises <see cref="Process"/> creation so that each process behaviour
+/// (capturing output, running silently in the background, opening a visible
+/// window, elevating, ...) is configured in exactly one place instead of being
+/// re-assembled at every call site. The behaviour is selected via
+/// <see cref="ProcessType"/>; the underlying flags are still applied through
+/// <see cref="ProcessBuilder"/>.
+/// </summary>
+public static class ProcessFactory
+{
+    /// <summary>
+    /// Creates a (non-started) <see cref="Process"/> configured for the given
+    /// <paramref name="type"/>.
+    /// </summary>
+    /// <param name="type">The behaviour the process should adopt.</param>
+    /// <param name="fileName">The executable to run (e.g. "cmd.exe").</param>
+    /// <param name="arguments">Optional command-line arguments.</param>
+    public static Process Create(ProcessType type, string fileName, string? arguments = null)
+    {
+        var builder = new ProcessBuilder(fileName);
+
+        if (!string.IsNullOrEmpty(arguments))
+        {
+            builder.SetArguments(arguments);
+        }
+
+        switch (type)
+        {
+            case ProcessType.ReadOutput:
+                builder.SetUseShellExecute(false)
+                       .SetRedirectStandardOutput(true)
+                       .SetCreateNoWindow(true);
+                break;
+
+            case ProcessType.ReadOutputAndError:
+                builder.SetUseShellExecute(false)
+                       .SetRedirectStandardOutput(true)
+                       .SetRedirectStandardError(true)
+                       .SetCreateNoWindow(true);
+                break;
+
+            case ProcessType.Background:
+                builder.SetUseShellExecute(false)
+                       .SetCreateNoWindow(true);
+                break;
+
+            case ProcessType.Interactive:
+                builder.SetUseShellExecute(true)
+                       .SetCreateNoWindow(true);
+                break;
+
+            case ProcessType.Elevated:
+                builder.SetUseShellExecute(true)
+                       .SetVerb("runas");
+                break;
+
+            case ProcessType.Default:
+                // Framework defaults: let the OS shell open the resource as-is.
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type), type, "Unsupported process type");
+        }
+
+        return builder.Build();
+    }
+}

--- a/LinuxManager/Builders/ProcessType.cs
+++ b/LinuxManager/Builders/ProcessType.cs
@@ -1,0 +1,46 @@
+namespace LinuxManager.Helpers;
+
+/// <summary>
+/// Describes how a process should behave once started. Each value maps to a
+/// single, centralised <see cref="System.Diagnostics.ProcessStartInfo"/>
+/// configuration in <see cref="ProcessFactory"/>, so call sites only have to
+/// pick an intent instead of re-assembling the same flags every time.
+/// </summary>
+public enum ProcessType
+{
+    /// <summary>
+    /// Runs hidden (no window) and captures the standard output stream.
+    /// Use when the caller needs to read the command's stdout.
+    /// </summary>
+    ReadOutput,
+
+    /// <summary>
+    /// Runs hidden (no window) and captures both the standard output and
+    /// standard error streams.
+    /// </summary>
+    ReadOutputAndError,
+
+    /// <summary>
+    /// Runs hidden (no window) without capturing any stream. Fire-and-forget
+    /// work such as terminating, shutting down or silently launching a distro.
+    /// </summary>
+    Background,
+
+    /// <summary>
+    /// Launched through the OS shell with a visible window so the user can
+    /// interact with it (e.g. opening a distribution in a terminal).
+    /// </summary>
+    Interactive,
+
+    /// <summary>
+    /// Launched through the OS shell with the "runas" verb to request
+    /// elevation (UAC prompt).
+    /// </summary>
+    Elevated,
+
+    /// <summary>
+    /// Framework defaults: lets the OS shell open the given resource
+    /// (e.g. opening a folder in Explorer).
+    /// </summary>
+    Default,
+}

--- a/LinuxManager/Helpers/WslHelper.cs
+++ b/LinuxManager/Helpers/WslHelper.cs
@@ -18,14 +18,8 @@ public static class WslHelper
 
     public static bool CheckHypervisor()
     {
-        var process = new ProcessBuilder("powershell.exe")
-            .SetArguments(
-                "/c (Get-WmiObject -Class \"Win32_ComputerSystem\" -ComputerName \"localhost\").HypervisorPresent")
-            .SetUseShellExecute(false)
-            .SetRedirectStandardOutput(true)
-            .SetRedirectStandardError(true)
-            .SetCreateNoWindow(true)
-            .Build();
+        var process = ProcessFactory.Create(ProcessType.ReadOutputAndError, "powershell.exe",
+            "/c (Get-WmiObject -Class \"Win32_ComputerSystem\" -ComputerName \"localhost\").HypervisorPresent");
         process.Start();
 
         var output = process.StandardOutput.ReadToEnd();
@@ -39,14 +33,8 @@ public static class WslHelper
 
     public static async Task<bool> CheckWslMicrosoftStore()
     {
-        var process = new ProcessBuilder("powershell.exe")
-            .SetArguments(
-                "/c  winget ls  -q 'WindowsSubsystemForLinux'")
-            .SetUseShellExecute(false)
-            .SetRedirectStandardOutput(true)
-            .SetRedirectStandardError(true)
-            .SetCreateNoWindow(true)
-            .Build();
+        var process = ProcessFactory.Create(ProcessType.ReadOutputAndError, "powershell.exe",
+            "/c  winget ls  -q 'WindowsSubsystemForLinux'");
         process.Start();
         var output = await process.StandardOutput.ReadToEndAsync();
 
@@ -55,12 +43,8 @@ public static class WslHelper
 
     public static async void InstallWslFromMicrosoftStore()
     {
-        var process = new ProcessBuilder("powershell.exe")
-            .SetArguments(
-                "/c  winget install 'Windows Subsystem for Linux'")
-            .SetUseShellExecute(true)
-            .SetVerb("runas")
-            .Build();
+        var process = ProcessFactory.Create(ProcessType.Elevated, "powershell.exe",
+            "/c  winget install 'Windows Subsystem for Linux'");
         process.Start();
         await process.WaitForExitAsync();
     }
@@ -70,13 +54,8 @@ public static class WslHelper
      */
     public static async Task ExportDistribution(string distroName, string destPath)
     {
-        var process = new ProcessBuilder("cmd.exe")
-            .SetArguments(
-                $"/c wsl --export {distroName} {destPath}")
-            .SetRedirectStandardOutput(true)
-            .SetUseShellExecute(false)
-            .SetCreateNoWindow(true)
-            .Build();
+        var process = ProcessFactory.Create(ProcessType.ReadOutput, "cmd.exe",
+            $"/c wsl --export {distroName} {destPath}");
         process.Start();
 
         await process.WaitForExitAsync();
@@ -89,13 +68,8 @@ public static class WslHelper
         WeakReferenceMessenger.Default.Send(new DistroProgressBarMessage("Importing your distribution ..."));
         try
         {
-            var process = new ProcessBuilder("cmd.exe")
-                .SetArguments($"/c md {installDir} & wsl --import {distroName} {installDir} {tarLocation}")
-                .SetRedirectStandardOutput(true)
-                .SetRedirectStandardError(true)
-                .SetUseShellExecute(false)
-                .SetCreateNoWindow(true)
-                .Build();
+            var process = ProcessFactory.Create(ProcessType.ReadOutputAndError, "cmd.exe",
+                $"/c md {installDir} & wsl --import {distroName} {installDir} {tarLocation}");
 
             process.Start();
             await process.WaitForExitAsync();
@@ -123,13 +97,8 @@ public static class WslHelper
         WeakReferenceMessenger.Default.Send(new DistroProgressBarMessage("Importing your distribution ..."));
         try
         {
-            var process = new ProcessBuilder("cmd.exe")
-                .SetArguments($"/c md {installDir} & wsl --import-in-place {distroName} {vhdxFilePath}")
-                .SetRedirectStandardOutput(true)
-                .SetRedirectStandardError(true)
-                .SetUseShellExecute(false)
-                .SetCreateNoWindow(true)
-                .Build();
+            var process = ProcessFactory.Create(ProcessType.ReadOutputAndError, "cmd.exe",
+                $"/c md {installDir} & wsl --import-in-place {distroName} {vhdxFilePath}");
 
             process.Start();
             await process.WaitForExitAsync();
@@ -153,12 +122,8 @@ public static class WslHelper
         Log.Information($"Check running distribution for {distroName}");
         try
         {
-            var process = new ProcessBuilder("cmd.exe")
-                .SetArguments("/c wsl --list --running --quiet")
-                .SetRedirectStandardOutput(true)
-                .SetUseShellExecute(false)
-                .SetCreateNoWindow(true)
-                .Build();
+            var process = ProcessFactory.Create(ProcessType.ReadOutput, "cmd.exe",
+                "/c wsl --list --running --quiet");
             process.Start();
 
             var output = process.StandardOutput.ReadToEndAsync().GetAwaiter().GetResult();
@@ -180,12 +145,8 @@ public static class WslHelper
         Log.Information($"Check existing distribution for {distroName}");
         try
         {
-            var process = new ProcessBuilder("cmd.exe")
-                .SetArguments("/c wsl --list --quiet")
-                .SetRedirectStandardOutput(true)
-                .SetUseShellExecute(false)
-                .SetCreateNoWindow(true)
-                .Build();
+            var process = ProcessFactory.Create(ProcessType.ReadOutput, "cmd.exe",
+                "/c wsl --list --quiet");
             process.Start();
 
             var output = process.StandardOutput.ReadToEndAsync().GetAwaiter().GetResult();
@@ -208,12 +169,8 @@ public static class WslHelper
 
         try
         {
-            var process = new ProcessBuilder("cmd.exe")
-                .SetArguments($"/c wsl --terminate {distroName}")
-                .SetRedirectStandardOutput(false)
-                .SetUseShellExecute(false)
-                .SetCreateNoWindow(true)
-                .Build();
+            var process = ProcessFactory.Create(ProcessType.Background, "cmd.exe",
+                $"/c wsl --terminate {distroName}");
             process.Start();
             await process.WaitForExitAsync();
         }
@@ -229,12 +186,8 @@ public static class WslHelper
 
         try
         {
-            var process = new ProcessBuilder("cmd.exe")
-                .SetArguments($"/c wsl --shutdown")
-                .SetRedirectStandardOutput(false)
-                .SetUseShellExecute(false)
-                .SetCreateNoWindow(true)
-                .Build();
+            var process = ProcessFactory.Create(ProcessType.Background, "cmd.exe",
+                "/c wsl --shutdown");
             process.Start();
             await process.WaitForExitAsync();
         }

--- a/LinuxManager/Services/DistributionInfosService.cs
+++ b/LinuxManager/Services/DistributionInfosService.cs
@@ -59,13 +59,8 @@ public class DistributionInfosService : IDistributionInfosService
         Log.Information($"Fetching disk usage for {distroName}");
         try
         {
-            var process = new ProcessBuilder("powershell.exe")
-                .SetArguments($"/c wsl.exe --system -d {distroName} df -B1 /mnt/wslg/distro")
-                .SetCreateNoWindow(true)
-                .SetUseShellExecute(false)
-                .SetRedirectStandardOutput(true)
-                .SetRedirectStandardError(true)
-                .Build();
+            var process = ProcessFactory.Create(ProcessType.ReadOutputAndError, "powershell.exe",
+                $"/c wsl.exe --system -d {distroName} df -B1 /mnt/wslg/distro");
             process.Start();
 
             var output = process.StandardOutput.ReadToEnd();

--- a/LinuxManager/Services/DistributionService.cs
+++ b/LinuxManager/Services/DistributionService.cs
@@ -126,10 +126,8 @@ public class DistributionService : IDistributionService
 
     public async Task RemoveDistribution(Distribution distribution)
     {
-        var process = new ProcessBuilder("cmd.exe")
-            .SetArguments($"/c wsl --unregister {distribution.Name}")
-            .SetCreateNoWindow(true)
-            .Build();
+        var process = ProcessFactory.Create(ProcessType.Background, "cmd.exe",
+            $"/c wsl --unregister {distribution.Name}");
         process.Start();
         await process.WaitForExitAsync();
 
@@ -227,12 +225,8 @@ public class DistributionService : IDistributionService
     {
         try
         {
-            var process = new ProcessBuilder("cmd.exe")
-                .SetArguments($"/c wsl ~ -d {distribution?.Name}")
-                .SetRedirectStandardOutput(false)
-                .SetUseShellExecute(true)
-                .SetCreateNoWindow(true)
-                .Build();
+            var process = ProcessFactory.Create(ProcessType.Interactive, "cmd.exe",
+                $"/c wsl ~ -d {distribution?.Name}");
             process.Start();
             Log.Information($"Launch process started (PID={process.Id}) for {distribution.Name}");
             distribution?.RunningProcesses.Add(process);
@@ -249,11 +243,8 @@ public class DistributionService : IDistributionService
         Log.Information($"Background start for {distribution.Name}");
         try
         {
-            var process = new ProcessBuilder("cmd.exe")
-                .SetArguments($"/c wsl -d {distribution?.Name}")
-                .SetCreateNoWindow(true)
-                .SetUseShellExecute(false)
-                .Build();
+            var process = ProcessFactory.Create(ProcessType.Background, "cmd.exe",
+                $"/c wsl -d {distribution?.Name}");
             process.Start();
         }
         catch (Exception ex)
@@ -296,10 +287,8 @@ public class DistributionService : IDistributionService
             {
                 BackgroundLaunchDistribution(distribution);
             }
-            var processBuilder = new ProcessBuilder("explorer.exe")
-                .SetArguments(distroFileSystem)
-                .Build();
-            processBuilder.Start();
+            var process = ProcessFactory.Create(ProcessType.Default, "explorer.exe", distroFileSystem);
+            process.Start();
         }
         catch (Exception ex)
         {
@@ -309,9 +298,8 @@ public class DistributionService : IDistributionService
 
     public void OpenDistributionWithVsCode(Distribution distribution)
     {
-        var process = new ProcessBuilder("cmd.exe")
-            .SetArguments($"/c wsl ~ -d {distribution.Name} code .")
-            .Build();
+        var process = ProcessFactory.Create(ProcessType.Default, "cmd.exe",
+            $"/c wsl ~ -d {distribution.Name} code .");
         process.Start();
     }
 
@@ -319,12 +307,8 @@ public class DistributionService : IDistributionService
     {
         try
         {
-            var process = new ProcessBuilder("cmd.exe")
-                .SetArguments($"/c wt wsl ~ -d {distribution?.Name}")
-                .SetRedirectStandardOutput(false)
-                .SetUseShellExecute(false)
-                .SetCreateNoWindow(true)
-                .Build();
+            var process = ProcessFactory.Create(ProcessType.Background, "cmd.exe",
+                $"/c wt wsl ~ -d {distribution?.Name}");
             process.Start();
             Log.Information($"Windows Terminal started (PID={process.Id}) for {distribution.Name}");
         }
@@ -348,10 +332,8 @@ public class DistributionService : IDistributionService
                 Log.Warning($"Installation location not found for {distribution.Name}: {target}");
                 return;
             }
-            var processBuilder = new ProcessBuilder("explorer.exe")
-                .SetArguments(target)
-                .Build();
-            processBuilder.Start();
+            var process = ProcessFactory.Create(ProcessType.Default, "explorer.exe", target);
+            process.Start();
             Log.Information($"Opening installation location: {target}");
         }
         catch (Exception ex)

--- a/LinuxManager/Views/UserControls/DisplaySnapshotsView.xaml.cs
+++ b/LinuxManager/Views/UserControls/DisplaySnapshotsView.xaml.cs
@@ -86,9 +86,7 @@ public sealed partial class DisplaySnapshotsView : UserControl
         Log.Information("Opening snapshots folder ...");
         try
         {
-            var process = new ProcessBuilder("explorer.exe")
-                .SetArguments(snapshotsFolderPath)
-                .Build();
+            var process = ProcessFactory.Create(ProcessType.Default, "explorer.exe", snapshotsFolderPath);
             process.Start();
         }
         catch (Exception ex)


### PR DESCRIPTION
## What
Centralises `Process` creation so each process *behaviour* is configured in one place instead of being re-assembled at every call site.

## How
- New `ProcessType` enum: `ReadOutput`, `ReadOutputAndError`, `Background`, `Interactive`, `Elevated`, `Default`
- New `ProcessFactory.Create(type, fileName, args)` maps each type to its `StartInfo` configuration
- All **19** call sites (`WslHelper`, `DistributionService`, `DistributionInfosService`, `DisplaySnapshotsView`) now request a `ProcessType`
- `ProcessBuilder` is kept as the factory''s internal mechanism, so its existing tests stay valid

Every mapping is **behaviour-preserving** (verified against each site''s original `StartInfo`).

## Verification
- ✅ Build OK (Release|x64)
- ✅ 103/103 tests green (94 existing + 9 new `ProcessFactoryTests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)