### PR TITLE
Clean up safe compiler and analyzer warnings

### DIFF
--- a/LinuxManager/Builders/ProcessBuilder.cs
+++ b/LinuxManager/Builders/ProcessBuilder.cs
@@ -2,8 +2,11 @@
 
 namespace LinuxManager.Helpers;
 
-// TODO : Add comment 
-
+/// <summary>
+/// Fluent builder around <see cref="Process"/>/<see cref="ProcessStartInfo"/>.
+/// Used by <see cref="ProcessFactory"/> to assemble the flags for each
+/// <see cref="ProcessType"/>; prefer the factory over instantiating this directly.
+/// </summary>
 public class ProcessBuilder
 {
     private readonly Process _process = new();

--- a/LinuxManager/Helpers/DockerHelper.cs
+++ b/LinuxManager/Helpers/DockerHelper.cs
@@ -19,7 +19,6 @@ public class DockerHelper
 
     private const string DOCKER_NAMED_PIPE = "npipe://./pipe/docker_engine";
     private const string DOCKER_REGISTRY = "https://registry.hub.docker.com/v2";
-    // private static readonly string DockerAuthToken = "auth.docker.io";
 
     public DockerHelper()
     {

--- a/LinuxManager/Helpers/FilesHelper.cs
+++ b/LinuxManager/Helpers/FilesHelper.cs
@@ -33,7 +33,7 @@ public static class FilesHelper
         {
             Directory.Delete(dirPath);
         }
-        catch (DirectoryNotFoundException ex)
+        catch (DirectoryNotFoundException)
         {
             Log.Error($"Cannot failed directory to remove at {dirPath}");
         }

--- a/LinuxManager/Helpers/RuntimeHelper.cs
+++ b/LinuxManager/Helpers/RuntimeHelper.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace LinuxManager.Helpers;
 
-public class RuntimeHelper
+public static class RuntimeHelper
 {
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
     private static extern int GetCurrentPackageFullName(ref int packageFullNameLength, StringBuilder? packageFullName);

--- a/LinuxManager/Helpers/TitleBarHelper.cs
+++ b/LinuxManager/Helpers/TitleBarHelper.cs
@@ -11,7 +11,7 @@ namespace LinuxManager.Helpers;
 // Helper class to workaround custom title bar bugs.
 // DISCLAIMER: The resource key names and color values used below are subject to change. Do not depend on them.
 // https://github.com/microsoft/TemplateStudio/issues/4516
-internal class TitleBarHelper
+internal static class TitleBarHelper
 {
     private const int WAINACTIVE = 0x00;
     private const int WAACTIVE = 0x01;

--- a/LinuxManager/Program.cs
+++ b/LinuxManager/Program.cs
@@ -8,7 +8,7 @@ namespace LinuxManager;
  * This class makes Linux Manager single-instanced.
  * For more details : https://blogs.windows.com/windowsdeveloper/2022/01/28/making-the-app-single-instanced-part-3/
  */
-public class Program
+public static class Program
 {
     [STAThread]
     static async Task<int> Main(string[] args)
@@ -33,7 +33,6 @@ public class Program
     {
         bool isRedirect = false;
         AppActivationArguments args = AppInstance.GetCurrent().GetActivatedEventArgs();
-        ExtendedActivationKind kind = args.Kind;
         AppInstance keyInstance = AppInstance.FindOrRegisterForKey("randomKey");
 
         if (keyInstance.IsCurrent)
@@ -50,6 +49,6 @@ public class Program
 
     private static void OnActivated(object sender, AppActivationArguments args)
     {
-        ExtendedActivationKind kind = args.Kind;
+        // No redirection handling required for subsequent activations.
     }
 }

--- a/LinuxManager/Services/DistributionService.cs
+++ b/LinuxManager/Services/DistributionService.cs
@@ -192,7 +192,7 @@ public class DistributionService : IDistributionService
             lxsSubKeys.Close();
             return false;
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             Log.Error("Failed to rename distribution in registry");
             return false;

--- a/LinuxManager/Services/UserInterface/ActivationService.cs
+++ b/LinuxManager/Services/UserInterface/ActivationService.cs
@@ -10,7 +10,7 @@ public class ActivationService : IActivationService
 {
     private readonly ActivationHandler<LaunchActivatedEventArgs> _defaultHandler;
     private readonly IEnumerable<IActivationHandler> _activationHandlers;
-    private UIElement? _shell = null;
+    private readonly UIElement? _shell = null;
 
     public ActivationService(ActivationHandler<LaunchActivatedEventArgs> defaultHandler, IEnumerable<IActivationHandler> activationHandlers)
     {


### PR DESCRIPTION
## What
Addresses a set of unambiguous, **behaviour-preserving** compiler/analyzer warnings.

| Rule | Fix |
|------|-----|
| S1118 | mark utility classes `static` (`RuntimeHelper`, `TitleBarHelper`, `Program`) |
| S1481 | remove unused `kind` locals in `Program` |
| CS0168 | drop unused exception variables (`FilesHelper`, `DistributionService`) |
| S125 | remove commented-out code (`DockerHelper`) |
| S2933 | make `ActivationService._shell` `readonly` |
| S1135 | replace the "Add comment" TODO on `ProcessBuilder` with a real doc comment |

## Deliberately left out
- The pervasive **nullable-reference** warnings (CS8618/8602/8604/8622) — need a dedicated annotation pass
- The two meaningful `Split code` / `Refactor` TODOs
- The WinUI-required `new App()` in `Program` (false-positive S1848)

## Verification
- ✅ Build OK (Release|x64), targeted warnings cleared, no new warnings
- ✅ 94/94 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)