### PR TITLE
docs: correct README license to GPL-3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A modern, open-source desktop application for managing Windows Subsystem for Linux (WSL) distributions on Windows. Built with .NET 8 and WinUI 3.
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Release](https://img.shields.io/github/v/release/NathanQuellec/linux-manager-for-windows)](https://github.com/NathanQuellec/linux-manager-for-windows/releases)
 [![Build Status](https://github.com/NathanQuellec/linux-manager-for-windows/actions/workflows/ci.yml/badge.svg)](https://github.com/NathanQuellec/linux-manager-for-windows/actions)
 [![CodeQL](https://github.com/NathanQuellec/linux-manager-for-windows/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/NathanQuellec/linux-manager-for-windows/actions/workflows/github-code-scanning/codeql)
@@ -122,7 +122,7 @@ When reporting bugs, please include:
 
 ## 📝 License
 
-This project is licensed under the MIT License — see [LICENSE.txt](LICENSE.txt) for details.
+This project is licensed under the GNU General Public License v3.0 (GPL-3.0) — see [LICENSE.txt](LICENSE.txt) for details.
 
 ---
 


### PR DESCRIPTION
## Summary
- fix README license badge from MIT to GPL v3
- update README license section to GNU GPL v3.0 (GPL-3.0)

Co-Authored-By: Oz <oz-agent@warp.dev>